### PR TITLE
fix the option label when using without checkbox and objects as values

### DIFF
--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -134,7 +134,7 @@
           name="singleLabel"
           slot-scope="scope"
         >
-          {{ scope.option }}
+          {{ getOptionLabel(scope.option) }}
         </slot>
       </template>
       <template slot="beforeList">


### PR DESCRIPTION
| Type  | Env Vars Change |
| :---: | :---: |
| Fix | No |

## Description
Small fix on input select. When using single select and objects as values, the label was displaying the full serialized object instead of the desired prop.

## Before & After Screenshots

**BEFORE**:
![before](https://user-images.githubusercontent.com/767624/43529990-dedace70-9582-11e8-91c7-1624fb4f5da6.gif)


**AFTER**:
![after](https://user-images.githubusercontent.com/767624/43529953-caa9f836-9582-11e8-9c2e-995899ec46c6.gif)
