### PR TITLE
fix: makes vi select perform case insensitive searches

### DIFF
--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -355,7 +355,7 @@ export default {
     },
     filteredOptions() {
       if (!this.searchValue) return this.options;
-      const pattern = new RegExp(this.searchValue);
+      const pattern = new RegExp(this.searchValue, 'i');
       return this.options
         .filter(option => pattern.test(this.customLabel(option, this.optionLabel)));
     },


### PR DESCRIPTION
| Type  | Env Vars Change |
| :---: | :---: |
| Fix| No |

## Description
VueUi makes case insensitive searches, but the piece of code that decides if the "check all" button must turn to "unselect all" don't.

## Before & After Screenshots

**BEFORE**:
![vi-select-rep](https://user-images.githubusercontent.com/767624/47084554-2e0daa00-d1ea-11e8-8ed9-55f0da8faede.gif)


**AFTER**:
![vi-select-fix](https://user-images.githubusercontent.com/767624/47084566-3534b800-d1ea-11e8-845b-324dc29b806f.gif)

