### PR TITLE
Add text truncation on vi-select

### DIFF
--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -498,6 +498,8 @@ export default {
 
       .multiselect__single
         font-size unset
+        padding 0 15px 0 0
+        @extend .text-truncate
 
     .multiselect__select
       z-index 3

--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -86,14 +86,12 @@
           name="option"
           v-bind="{ option }"
         >
-          <template v-if="checkbox">
-            <span class="ViInput__MultiselectCheckbox">
-              {{ getOptionLabel(option) }}
-            </span>
-          </template>
-          <template v-else>
+          <span
+            :class="{ 'ViInput__MultiselectCheckbox': checkbox }"
+            :title="getOptionLabel(option)"
+          >
             {{ getOptionLabel(option) }}
-          </template>
+          </span>
         </slot>
       </template>
 
@@ -511,6 +509,9 @@ export default {
         &:before
           border-color $border-color-main-focus transparent transparent
 
+    .multiselect__content
+      width 100%
+
     .multiselect__content-wrapper
       border-color $border-color-main
       border-bottom-width 2px
@@ -532,6 +533,7 @@ export default {
     .multiselect__checkoption
     .multiselect__option
       border-bottom 1px solid rgba($border-color-main, 0.5)
+      @extend .text-truncate
 
       &:after
         font-weight 700

--- a/src/themes/main.styl
+++ b/src/themes/main.styl
@@ -261,3 +261,8 @@ html
   /* Track */
   ::-webkit-scrollbar-track
     background transparent
+
+.text-truncate
+  white-space nowrap
+  overflow hidden
+  text-overflow ellipsis


### PR DESCRIPTION
| Type  | Env Vars Change |
| :---: | :---: |
| Feature| No |

This PR add text truncation on vi-select. It acts on options and the main button:

![image](https://user-images.githubusercontent.com/767624/47114499-5a4d1900-d232-11e8-8f0d-e94c88b59e54.png)

![image](https://user-images.githubusercontent.com/767624/47114516-676a0800-d232-11e8-9556-9803a2e07f0f.png)



