### PR TITLE
fix: when the component is loading, the dropown arrow is hidden

### DIFF
--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -71,6 +71,7 @@
           :toggle="toggle"
         >
           <div
+            v-if="!loading"
             tabindex="0"
             class="multiselect__select"
             @keydown.enter.prevent.stop="toggle"

--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -71,7 +71,7 @@
           :toggle="toggle"
         >
           <div
-            v-if="!loading"
+            v-show="!loading"
             tabindex="0"
             class="multiselect__select"
             @keydown.enter.prevent.stop="toggle"


### PR DESCRIPTION
| Type  | Env Vars Change |
| :---: | :---: |
| Fix | No |

## Description

When the component is loading, the spinner is shown, and the dropown arrow is hidden

