### PR TITLE
feature: Add dynamic slots to ViTable

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -69,7 +69,13 @@
             <span class="ViTable__FakeCheckbox" />
           </div>
         </td>
-        <slot :item="item" />
+        <slot :item="item">
+          <td v-for="(column, index) in columns" :key="index">
+            <slot :name="`column-${column.id}`" v-bind:item="item">
+              {{ item[column.id] }}
+            </slot>
+          </td>
+        </slot>
       </tr>
     </tbody>
   </table>
@@ -415,10 +421,76 @@ export default {
 </style>
 
 <docs>
-### Basic Table
+### Tabela Básica
 
-Para alinhar o conteúdo das células da coluna em uma direção,
-adicione [center|right] como uma propriedade na coluna.
+A forma mais simples de utilizar o ViTable é apenas definir as colunas e dados que devem ser exibidos:
+
+> Dica: Para alinhar o conteúdo das células da coluna em uma direção,
+> adicione [center|right] como uma propriedade na coluna.
+
+```vue
+<template>
+  <vi-table :columns="columns" :items="data" />
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        columns: [
+          { id: 'id', label: 'ID' },
+          { id: 'name', label: 'Name' },
+          { id: 'email', label: 'E-mail' },
+        ],
+        data: [
+          { id: 1, name: 'Amanda', email: 'amanda@vitta.com.br' },
+          { id: 2, name: 'Beth', email: 'beth@vitta.com.br' },
+          { id: 3, name: 'Cleusa', email: 'cleusa@vitta.com.br' },
+          { id: 4, name: 'Darlene', email: 'darlene@vitta.com.br' },
+          { id: 5, name: 'Eleonora', email: 'eleonora@vitta.com.br' },
+        ],
+      };
+    },
+  };
+</script>
+```
+
+É possível personalizar a renderização de cada coluna utilizando um slot com o identificador da coluna.
+Veja no exemplo abaixo como personalizar a renderização da coluna e-mail.
+
+```vue
+<template>
+  <vi-table :columns="columns" :items="data">
+    <template v-slot:column-email="{ item }" >
+      <a :href="'mailto:' + item.email">{{ item.email }}</a>
+    </template>
+  </vi-table>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        columns: [
+          { id: 'id', label: 'ID' },
+          { id: 'name', label: 'Name' },
+          { id: 'email', label: 'E-mail' },
+        ],
+        data: [
+          { id: 1, name: 'Amanda', email: 'amanda@vitta.com.br' },
+          { id: 2, name: 'Beth', email: 'beth@vitta.com.br' },
+          { id: 3, name: 'Cleusa', email: 'cleusa@vitta.com.br' },
+          { id: 4, name: 'Darlene', email: 'darlene@vitta.com.br' },
+          { id: 5, name: 'Eleonora', email: 'eleonora@vitta.com.br' },
+        ],
+      };
+    },
+  };
+</script>
+```
+
+### Tabela Completa
+Também é possível utilizar as demais funcionalidades do componente com um pouco mais de código, incluindo total controle da renderização de cada linha.
 
 ```vue
 <template>
@@ -435,8 +507,8 @@ adicione [center|right] como uma propriedade na coluna.
   >
     <template slot-scope="{ item }">
       <td center>{{ item.id }}</td>
-      <td>{{ item.name }}</td>
-      <td>{{ item.company }}</td>
+      <td :style="{ color: 'green' }">{{ item.name }}</td>
+      <td right>{{ item.company }}</td>
     </template>
     <template slot="tfoot">
       <td center>Sum</td>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -443,11 +443,11 @@ A forma mais simples de utilizar o ViTable é apenas definir as colunas e dados 
           { id: 'email', label: 'E-mail' },
         ],
         data: [
-          { id: 1, name: 'Amanda', email: 'amanda@vitta.com.br' },
-          { id: 2, name: 'Beth', email: 'beth@vitta.com.br' },
-          { id: 3, name: 'Cleusa', email: 'cleusa@vitta.com.br' },
-          { id: 4, name: 'Darlene', email: 'darlene@vitta.com.br' },
-          { id: 5, name: 'Eleonora', email: 'eleonora@vitta.com.br' },
+          { id: 1, name: 'Amanda', email: 'amanda@example.com' },
+          { id: 2, name: 'Beth', email: 'beth@example.com' },
+          { id: 3, name: 'Cleusa', email: 'cleusa@example.com' },
+          { id: 4, name: 'Darlene', email: 'darlene@example.com' },
+          { id: 5, name: 'Eleonora', email: 'eleonora@example.com' },
         ],
       };
     },
@@ -477,11 +477,11 @@ Veja no exemplo abaixo como personalizar a renderização da coluna e-mail.
           { id: 'email', label: 'E-mail' },
         ],
         data: [
-          { id: 1, name: 'Amanda', email: 'amanda@vitta.com.br' },
-          { id: 2, name: 'Beth', email: 'beth@vitta.com.br' },
-          { id: 3, name: 'Cleusa', email: 'cleusa@vitta.com.br' },
-          { id: 4, name: 'Darlene', email: 'darlene@vitta.com.br' },
-          { id: 5, name: 'Eleonora', email: 'eleonora@vitta.com.br' },
+          { id: 1, name: 'Amanda', email: 'amanda@example.com' },
+          { id: 2, name: 'Beth', email: 'beth@example.com' },
+          { id: 3, name: 'Cleusa', email: 'cleusa@example.com' },
+          { id: 4, name: 'Darlene', email: 'darlene@example.com' },
+          { id: 5, name: 'Eleonora', email: 'eleonora@example.com' },
         ],
       };
     },

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -11,11 +11,11 @@ module.exports = {
   sections: [
     {
       name: 'Instalação e Utilização',
-      content: 'docs/pages/installation.md',
+      content: 'docsSrc/pages/installation.md',
     },
     {
       name: 'Tipografia e Cores',
-      content: 'docs/pages/thypography-colors.md',
+      content: 'docsSrc/pages/thypography-colors.md',
     },
     {
       name: 'Documentação',


### PR DESCRIPTION
## Description

This PR add dynamic slots to ViTable and simple default render for cells. Now is possible to render a simple table without the need to code `<td>` and customize individual cells if necessary.

## Before & After Screenshots

**BEFORE**:
[insert screenshot here]
![image](https://user-images.githubusercontent.com/767624/67218403-b4139080-f3fc-11e9-8e31-1daf36fa09d7.png)


**AFTER**:
![personalizacao-slot](https://user-images.githubusercontent.com/767624/67218480-d1485f00-f3fc-11e9-879d-1f41bda504cf.png)
![tabela-basica](https://user-images.githubusercontent.com/767624/67218481-d1485f00-f3fc-11e9-86f2-a9f4a23bcdce.png)



