### PR TITLE
Fqdn in Travis File

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
       deploy:
         provider: pages
         skip_cleanup: true
+        fqdn: viui.dev
         commiter_from_gh: true
         github_token: $GITHUB_TOKEN
         on:


### PR DESCRIPTION
## Description
We removed the fqdn attribute in travis file because viui.dev was not working back then. Now that it's working we need to put it back so that when the deploy is triggered the custom domain keeps working
