### PR TITLE
Fix coverage report

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   coverageDirectory: './coverage/',
   collectCoverage: true,
   moduleFileExtensions: ['js', 'json', 'vue'],
+  collectCoverageFrom: ['src/**/*.js', 'src/**/*.vue'],
   transform: {
     '.*\\.(vue)$': 'vue-jest',
     '^.+\\.js$': 'babel-jest',


### PR DESCRIPTION
## Description
The coverage report was calculating only the files that had test, so the percentage was wrong. This PR fix this, the coverage will count all .js and .vue files.

**AFTER**:
![real_coverage](https://user-images.githubusercontent.com/33661847/68779637-b8098b80-0613-11ea-9e46-c664b73e5f62.png)
