### PR TITLE
fix: Fix ViButton content aligment

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -147,6 +147,7 @@ export default {
 @import '../themes/main'
 
 .ViComponent.ViButton
+  align-items center
   border-radius 0.2em
   border-style solid
   border-width 0.09em


### PR DESCRIPTION
## Description
Added align-items to ViButton to fix the misalignment on chrome.


## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/767624/83047855-5775f500-a01f-11ea-932b-30db97362728.png)


**AFTER**:
[insert screenshot here]
![image](https://user-images.githubusercontent.com/767624/83047868-5e9d0300-a01f-11ea-9ece-799ecbb0b13b.png)


* [insert ticket name here](insert link here)


fixes #93